### PR TITLE
Fixes to rules about Pi

### DIFF
--- a/src/refiner/rules/general.sig
+++ b/src/refiner/rules/general.sig
@@ -22,8 +22,8 @@ sig
    *)
   val Hyp : Utils.target -> PrlTactic.t
 
-  (* H >> C
-   *   H(i) = C
+  (* H >> x = x in A
+   *   H(x) = A
    * Uses: VAR_EQ
    *)
   val HypEq : PrlTactic.t

--- a/src/refiner/rules/pi.sml
+++ b/src/refiner/rules/pi.sml
@@ -180,7 +180,9 @@ struct
         return { goals = [ cxt >> EQ (f1, f1, PI (A, B))
                          , cxt >> EQ (f2, f2, PI (A, B))
                          (* Here is the spot I was referencing *)
-                         , B ::: cxt >> EQ (lift 0 1 f1, lift 0 1 f2, B)
+                         , A ::: cxt >> EQ (AP (lift 0 1 f1, Term.VAR 0),
+                                            AP (lift 0 1 f2, Term.VAR 0),
+                                            B)
                          ]
                , evidence = fn [d1, d2, d3] => FUN_EXT (d1, d2, d3)
                              | _ => raise MalformedEvidence

--- a/src/refiner/rules/pi.sml
+++ b/src/refiner/rules/pi.sml
@@ -122,7 +122,7 @@ struct
     case nth (irrelevant t) target cxt of
         SOME (PI (A, B)) =>
         return { goals = [ cxt >> EQ (arg, arg, A)
-                         , subst arg 0 B ::: cxt >> t
+                         , subst arg 0 B ::: cxt >> lift 0 1 t
                          ]
                , evidence = fn [d1, d2] => PI_ELIM (target, arg, d1, d2)
                              | _ => raise MalformedEvidence

--- a/test/simple-proofs.sml
+++ b/test/simple-proofs.sml
@@ -88,4 +88,31 @@ struct
         [ Ceq.Eq split [Ceq.Refl, Ceq.Refl]
         , General.Hyp 0
         , Ceq.Step next Ceq.Refl]]);
+
+  (* Pi tests *)
+  val () = mustProve "Pi.FunExt"
+                (PI (UNI 0,
+                 PI (UNI 0,
+                 PI (PI (VAR 1, VAR 1),
+                 PI (PI (VAR 2, VAR 2),
+                 PI (PI (VAR 3, EQ (AP (VAR 2, VAR 0),
+                                    AP (VAR 1, VAR 0),
+                                    VAR 3)),
+                 EQ (VAR 2, VAR 1, PI (VAR 4, VAR 4))))))))
+
+                (Pi.Intro 1 split [Uni.Eq,
+                 Pi.Intro 1 split [Uni.Eq,
+                 Pi.Intro 0 split [Pi.Eq split [General.HypEq, General.HypEq],
+                 Pi.Intro 0 split [Pi.Eq split [General.HypEq, General.HypEq],
+                 Pi.Intro 0 split [Pi.Eq split [General.HypEq,
+                                    Eq.Eq split [General.HypEq,
+                                                 Pi.ApEq 0 (PI (VAR 4, VAR 4)) next
+                                                         General.HypEq,
+                                                 Pi.ApEq 0 (PI (VAR 4, VAR 4)) next
+                                                   General.HypEq]],
+                 Pi.FunExt split [General.HypEq, General.HypEq,
+                     Pi.Elim 1 (VAR 0) split [
+                         General.HypEq,
+                         General.Hyp 0
+                     ]]]]]]]);
 end


### PR DESCRIPTION
This fixes a couple problems with the implementation of the rules about Pi. 
- Functional extensionality: The rule is documented correctly in `pi.sig`, but the implementation does not match the documentation. In particular, in the third subgoal, it assigns the new variable type `B` instead of `A`, and it does not apply the functions to the new variable.
- Elimination: There is a de Bruijn error in the second subgoal. It adds a hypothesis to the context without lifting the goal.

I added a kind of long test that shows off both of these rules correctly to prove function extensionality in the special case where the function's type is not dependent. It's unreadable, but it type checks! :)

Somewhat unrelatedly, I also fixed the docs for General.HypEq. I'm happy to submit this as a separate PR if you prefer.
