### PR TITLE
Fixes to rules about Sig

### DIFF
--- a/src/refiner/rules/sig.sml
+++ b/src/refiner/rules/sig.sml
@@ -67,9 +67,9 @@ struct
 
   fun SndEq uni tp (cxt >> t) =
     case (tp, t) of
-        (SIG (A, B), EQ (FST m1, FST m2, A')) =>
+        (SIG (A, B), EQ (SND m1, SND m2, B')) =>
         return { goals = [ cxt >> EQ (m1, m2, tp)
-                         , cxt >> EQ (subst (FST m1) 0 B, B, UNI uni) ]
+                         , cxt >> EQ (subst (FST m1) 0 B, B', UNI uni) ]
                , evidence = fn [d1, d2] => SND_EQ (uni, tp, d1, d2)
                              | _ => raise MalformedEvidence
                }

--- a/src/refiner/rules/sig.sml
+++ b/src/refiner/rules/sig.sml
@@ -36,7 +36,7 @@ struct
   fun Elim target (cxt >> t) =
     case nth (irrelevant t) target cxt of
         SOME (SIG (A, B)) =>
-        return { goals = [ B ::: A ::: cxt >> t ]
+        return { goals = [ B ::: A ::: cxt >> lift 0 2 t ]
                , evidence = fn [d] => SIG_ELIM (target, d)
                              | _  => raise MalformedEvidence
                }

--- a/test/simple-proofs.sml
+++ b/test/simple-proofs.sml
@@ -115,4 +115,24 @@ struct
                          General.HypEq,
                          General.Hyp 0
                      ]]]]]]]);
+
+  (* Sig tests *)
+  val () = mustProve "Sig.Elim"
+              (PI (UNI 0,
+               PI (PI (VAR 0, UNI 0),
+               PI (SIG (VAR 1, AP (VAR 1, VAR 0)),
+               VAR 2))))
+              (Pi.Intro 1 split [Uni.Eq,
+               Pi.Intro 1 split [Pi.Eq split [Uni.Cumulative next General.HypEq, Uni.Eq],
+               Pi.Intro 0 split [Sig.Eq split [General.HypEq,
+                                               Pi.ApEq 1 (PI (VAR 2, UNI 0)) split
+                                                       [General.HypEq, General.HypEq, Uni.Eq]],
+               Sig.Elim 0 split [General.Hyp 1]]]]);
+
+  val () = mustProve "Sig.SndEq"
+              (EQ (SND (PAIR (TT, TT)), SND (PAIR (TT, TT)), UNIT))
+              (Sig.SndEq 0 (SIG (UNIT, UNIT)) split [
+                    Sig.PairEq 0 split [Unit.TTEq, Unit.TTEq, Unit.Eq] ,
+                    Unit.Eq
+                ])
 end


### PR DESCRIPTION
This fixes two problems with the rules about sigmas. 
- Sig.Elim has a de Bruijn problem where it adds two hypotheses to the context but does not lift the goal.
- Sig.SndEq has a copy-paste error where it accidentally talks about `FST` instead of `SND`; it also mistakenly refers to `B` instead of `B'` in one subgoal, resulting in an unsound and ill-scoped rule. 

I also added tests that exercise these rules.
