### PR TITLE
Improve nat docs

### DIFF
--- a/src/refiner/rules/nat.sig
+++ b/src/refiner/rules/nat.sig
@@ -1,9 +1,33 @@
 signature NAT_RULES =
 sig
+  (* H >> nat = nat in U(i)
+   *)
   val Eq : PrlTactic.t
+
+  (* H >> nat
+   *)
   val Intro : PrlTactic.t
+
+  (* H >> A
+   *   H(i) = nat
+   *   H, zero = i in nat >> [zero/i]A
+   *   H, n : nat, rec : [n/i]A, suc(n) = i : A >> [suc(n)/i]A
+   *)
   val Elim : Utils.target -> PrlTactic.t
+
+  (* H >> zero = zero in nat
+   *)
   val ZeroEq : PrlTactic.t
+
+  (* H >> suc(n) = suc(m) in nat
+   *   H >> n = m in natural
+   *)
   val SuccEq : PrlTactic.t
+
+  (* H >> rec(n; z; x.y.s) = rec(n'; z'; x.y.s') in A
+   *   H >> n = n' in nat
+   *   H >> z = z' in A
+   *   H, x : nat, y : A >> s = s' in A
+   *)
   val RecEq : PrlTactic.t
 end

--- a/src/refiner/rules/nat.sml
+++ b/src/refiner/rules/nat.sml
@@ -40,7 +40,7 @@ struct
          * substitution but we have to use substOpen to make sure that the
          * result still makes sense in cxt.
          *
-         * As an added wrinkle, we're adding things to our constant so we have
+         * As an added wrinkle, we're adding things to our context so we have
          * to carefully apply lifts to the appropriate places. Finally, as
          * we change the context, the value we need to substitute for (target)
          * changes because it's at different positions in the context.


### PR DESCRIPTION
This PR adds documentation to `nat.sig` for the inference rules having to do with nats. I also fixed a small typo in `nat.sml`.

I would also like to hijack this to ask for the motivation for choosing this particular elimination rule, which adds an equality to the context in each subgoal. As far as I can tell, neither JonPRL nor NuPRL (analogizing nat to int) do this. 
